### PR TITLE
Update deploy_miner_cn.md

### DIFF
--- a/docs/deploy/deploy_miner_cn.md
+++ b/docs/deploy/deploy_miner_cn.md
@@ -83,7 +83,7 @@ log_dir: "/var/log/miner"
 #设置zookeeper内网ip地址
   zk-registry:
     protocol: zookeeper
-    host: xx.xx.xx.xx,xx.xx.xx.xx,xx.xx.xx.xx
+    host: xx.xx.xx.xx
     port: 2181
 ```
 * tokens.json


### PR DESCRIPTION
通过实践发现，motan_client.yaml 的host填3个逗号分割，程序报空指针错误。。。。。填一个就没问题，这个问题困扰了我好久好久