### PR TITLE
修复 AuthPrivateKey.Address() bug 点，可能导致底层内存溢出。此修改配合 relay-lib 的 crypto.go

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -242,8 +242,14 @@ func (f *BaseFilter) filter(o *types.Order) (bool, error) {
 		return false, fmt.Errorf("protocol and Delegate are not matched")
 	}
 
-	if o.OrderType == types.ORDER_TYPE_MARKET && o.AuthPrivateKey.Address() != o.AuthAddr {
-		return false, fmt.Errorf("market order auth private key not correct")
+	if o.OrderType == types.ORDER_TYPE_MARKET {
+		authPriAddress := o.AuthPrivateKey.Address()
+		if authPriAddress == common.StringToAddress("0x0") {
+			return false, fmt.Errorf("very bad! market type but no pri key")
+		}
+		if authPriAddress != o.AuthAddr {
+			return false, fmt.Errorf("market order auth private key not correct")
+		}
 	}
 
 	if o.TokenB != util.AliasToAddress("LRC") {

--- a/vendor/github.com/Loopring/relay-lib/crypto/crypto.go
+++ b/vendor/github.com/Loopring/relay-lib/crypto/crypto.go
@@ -117,6 +117,9 @@ func (c EthPrivateKeyCrypto) Sign(hashPre []byte, signerAddr common.Address) ([]
 }
 
 func (c EthPrivateKeyCrypto) Address() common.Address {
+	if c.privateKey == nil {
+		return common.StringToAddress("0x0")
+	}
 	return ethCrypto.PubkeyToAddress(c.privateKey.PublicKey)
 }
 


### PR DESCRIPTION
修改 baseFilter 在 o.OrderType 为 types.ORDER_TYPE_MARKET 时候，客户端没传 priKey 时候导致 o.AuthPrivateKey.Address() 内部进入后在底层出错。因为原 Address() 没做指针判空。导致的现象就是，代码运行到改行，停止往下进行，无任何输出，也不崩溃。测试重现请按如下步骤即可。客户端的 orderType 传 mark 类型的，但是不传 AuthPrivateKey 。就能看到了。